### PR TITLE
Remove Shopify analytics code

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,7 +18,6 @@
     <script src="javascripts/custom-repos.js"></script>
     <script src="javascripts/shopify-opensource.js"></script>
 
-    <script type="text/javascript" src="//visitors.shopify.com/track.js?v=2"></script>
     <script type="text/javascript">_visit.tag('open source');</script>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
We were accidentally leaking analytics to the upstream creator of this repository (Shopify). This removes that code.